### PR TITLE
Add missing kernels, rename FfmpegBicubic

### DIFF
--- a/vskernels/kernels/bicubic.py
+++ b/vskernels/kernels/bicubic.py
@@ -13,7 +13,7 @@ __all__ = [
     'Hermite',
     'Mitchell',
     'Catrom',
-    'FFmpegBicubic',
+    'SwscaleBicubic',
     'AdobeBicubic',
     'AdobeBicubicSharper',
     'AdobeBicubicSmoother',
@@ -105,7 +105,7 @@ class Catrom(Bicubic):
         super().__init__(b=0, c=1 / 2, **kwargs)
 
 
-class FFmpegBicubic(Bicubic):
+class SwscaleBicubic(Bicubic):
     """Bicubic b=0, c=0.6; FFmpeg's swscale default"""
 
     def __init__(self, **kwargs: Any) -> None:

--- a/vskernels/kernels/bicubic.py
+++ b/vskernels/kernels/bicubic.py
@@ -15,6 +15,8 @@ __all__ = [
     'Catrom',
     'FFmpegBicubic',
     'AdobeBicubic',
+    'AdobeBicubicSharper',
+    'AdobeBicubicSmoother',
     'BicubicSharp',
     'RobidouxSoft',
     'Robidoux',
@@ -115,6 +117,20 @@ class AdobeBicubic(Bicubic):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(b=0, c=3 / 4, **kwargs)
+
+
+class AdobeBicubicSharper(Bicubic):
+    """Bicuboc b=0, c=1, blur=1.05; Adobe's "Bicubic Sharper" interpolation preset."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(b=0, c=1, blur=1.05, **kwargs)
+
+
+class AdobeBicubicSmoother(Bicubic):
+    """Bicuboc b=0, c=0.625, blur=1.15 ; Adobe's "Bicubic Smoother" interpolation preset."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(b=0, c=5 / 8, blur=1.15, **kwargs)
 
 
 class BicubicSharp(Bicubic):

--- a/vskernels/kernels/bicubic.py
+++ b/vskernels/kernels/bicubic.py
@@ -120,14 +120,14 @@ class AdobeBicubic(Bicubic):
 
 
 class AdobeBicubicSharper(Bicubic):
-    """Bicuboc b=0, c=1, blur=1.05; Adobe's "Bicubic Sharper" interpolation preset."""
+    """Bicubic b=0, c=1, blur=1.05; Adobe's "Bicubic Sharper" interpolation preset."""
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(b=0, c=1, blur=1.05, **kwargs)
 
 
 class AdobeBicubicSmoother(Bicubic):
-    """Bicuboc b=0, c=0.625, blur=1.15 ; Adobe's "Bicubic Smoother" interpolation preset."""
+    """Bicubic b=0, c=0.625, blur=1.15 ; Adobe's "Bicubic Smoother" interpolation preset."""
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(b=0, c=5 / 8, blur=1.15, **kwargs)


### PR DESCRIPTION
Adding missing kernels we uncovered some time ago, as well as renaming FfmpegBicubic.