### PR TITLE
Kernel: Properly pass src instead of clip to shift

### DIFF
--- a/vskernels/kernels/abstract.py
+++ b/vskernels/kernels/abstract.py
@@ -403,7 +403,7 @@ class Kernel(Scaler, Descaler, Resampler):  # type: ignore
         n_planes = clip.format.num_planes
 
         def _shift(src: vs.VideoNode, shift: tuple[TopShift, LeftShift] = (0, 0)) -> vs.VideoNode:
-            return Scaler.scale(self, clip, **kwargs)
+            return Scaler.scale(self, src, **kwargs)
 
         if not shifts_or_top and not shift_left:
             return _shift(clip)


### PR DESCRIPTION
```py
Catrom.shift(src, 0, [0, -0.1], width=1920, height=1080)
```

Jaded-Encoding-Thaumaturgy/vs-kernels@73419b2399ce8e1d652bbf07d543245214d9d621 https://slow.pics/c/i24USIb5
Jaded-Encoding-Thaumaturgy/vs-kernels@491c75432909ffcb56522c080bf16e8b1d462383 https://slow.pics/c/HeSSBN1c