### PR TITLE
Fix an issue where linear light scalers may shift colors

### DIFF
--- a/vskernels/util.py
+++ b/vskernels/util.py
@@ -230,7 +230,7 @@ class LinearLight:
 
         self._wclip = cast(ConstantFormatVideoNode, depth(self.clip, 32) if self.sigmoid else self.clip)
         self._curve = Transfer.from_video(self.clip)
-        self._matrix = Matrix.from_transfer(self._curve)
+        self._matrix = Matrix.from_video(self.clip)
         self._resampler = Catrom.ensure_obj(self.resampler)
 
         self._exited = False


### PR DESCRIPTION
Fixes https://github.com/Jaded-Encoding-Thaumaturgy/vs-scale/issues/90

Comparison (Before/Bicubic/After): https://slow.pics/c/O81m3GBg