### PR TITLE
Remove `EwaBicubic`

### DIFF
--- a/vskernels/kernels/placebo.py
+++ b/vskernels/kernels/placebo.py
@@ -11,7 +11,6 @@ from .complex import LinearScaler
 
 __all__ = [
     'Placebo',
-    'EwaBicubic',
     'EwaJinc',
     'EwaLanczos',
     'EwaGinseng',
@@ -98,20 +97,6 @@ class Placebo(LinearScaler):
             return Bicubic(fallback(self.b, 0), fallback(self.c, 0.5)).kernel_radius
 
         return 2
-
-
-class EwaBicubic(Placebo):
-    _kernel = 'ewa_robidoux'
-
-    def __init__(self, b: float = 0.0, c: float = 0.5, radius: int | None = None, **kwargs: Any) -> None:
-        radius = kwargs.pop('taps', radius)
-
-        if radius is None:
-            from .bicubic import Bicubic
-
-            radius = Bicubic(b, c).kernel_radius
-
-        super().__init__(radius, b, c, **kwargs)
 
 
 class EwaLanczos(Placebo):


### PR DESCRIPTION
Firstly, it was incorrectly referencing ewa_robidoux, which _is_ a bicubic but internally its `b` and `c` params take precedence over anything a user might have passed to `EwaBicubic`, so functionally it was equivalent to `EwaRobidoux`. Secondly, there is no "ewa_bicubic" to replace it with; there's "bicubic" but I think we've got that kernel sufficiently covered with `Bicubic` elsewhere.